### PR TITLE
Fix installation / startup of genenotebook (regex email undefined)

### DIFF
--- a/cli/genenotebook.js
+++ b/cli/genenotebook.js
@@ -292,7 +292,7 @@ addAnnotation
   .option('-u, --username <username>', 'GeneNoteBook admin username')
   .option('-p, --password <password>', 'GeneNoteBook admin password')
   .option(
-    '-n, --genome-name <name>',
+    '-n, --name <name>',
     'Reference genome name to which the annotation should be added'
   )
   .option(
@@ -303,8 +303,9 @@ addAnnotation
   .action(
     (
       file,
-      { username, password, genomeName, port = 3000, verbose = false }
+      { username, password, name, port = 3000, verbose = false }
     ) => {
+      logger.log('genomeName', name);
       if (typeof file !== 'string') addAnnotation.help();
       const fileName = path.resolve(file);
 
@@ -314,7 +315,7 @@ addAnnotation
 
       new GeneNoteBookConnection({ username, password, port }).call(
         'addAnnotationTrack',
-        { fileName, genomeName, verbose }
+        { fileName, genomeName: name, verbose }
       );
     }
   )

--- a/imports/api/users/users.js
+++ b/imports/api/users/users.js
@@ -73,8 +73,16 @@ export const editUserInfo = new ValidatedMethod({
     'emails.$': { type: Object },
     'emails.$.address': {
       type: String,
-      regEx: SimpleSchema.RegEx.Email,
-      optional: true,
+      custom() {
+        let regexEmail = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+        if (!regexEmail.test(this.obj.emails[0].address)) {
+          throw new Meteor.Error(
+            'Error, invalid email',
+            'Please enter a valid email address.',
+          );
+        }
+        return true;
+      },
     },
     role: {
       type: String,
@@ -182,8 +190,17 @@ export const addUser = new ValidatedMethod({
     newPassword: { type: String },
     emails: {
       type: String,
-      regEx: SimpleSchema.RegEx.Email,
       optional: true,
+      custom() {
+        let regexEmail = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+        if (!regexEmail.test(this.obj.emails)) {
+          throw new Meteor.Error(
+            'Error, invalid email',
+            'Please enter a valid email address.',
+          );
+        }
+        return true;
+      },
     },
     profile: {
       type: Object,


### PR DESCRIPTION
Hi @holmrenser :)
For obscure reasons, the startup and thus the installation of genenotebook did not work because of an **undefined Email value** in the file /imports/api/users/users.js

```bash
TypeError: Cannot read property 'Email' of undefined
```

I fixed the bug as indicated [here](https://www.npmjs.com/package/simpl-schema?activeTab=readme#regex) by creating a custom regex function to check the validity when creating or editing a user. (Inspired from [here](https://github.com/longshotlabs/meteor-simple-schema/blob/803bfc9155de6a9fae99eba3df2d5c7a7624097b/simple-schema.js#L545))

PS: I also changed the **--name** parameter for the annotation as shown in the [official documentation](https://genenotebook.github.io/documentation/adding-annotation) instead of **--genome-name** which is not in the official documentation.

We will get something like this : 
```
genenotebook add annotation --name "mucor" annot.gff -u admin -p admin
```

:+1: 